### PR TITLE
docs: enhance EC2 basics and lab template

### DIFF
--- a/docs/en/03-services/compute/ec2/basics.md
+++ b/docs/en/03-services/compute/ec2/basics.md
@@ -6,6 +6,14 @@
 - You can access EC2 via the console, CLI, SDKs, or Infrastructure as Code tools (CloudFormation/Terraform), but the core concepts (AMI, instance type, VPC, Security Group, key pair) are the same.
 - Good day‑0 setup (IAM Role, Security Groups, tags, monitoring) dramatically simplifies day‑2 operations (patching, scaling, troubleshooting, cost control).
 
+## Service at a Glance
+
+| Choose EC2 when you need… | Consider alternatives when… |
+| --- | --- |
+| Full control of OS, networking, placement groups, and licensing requirements. | You only need managed containers or serverless runtimes (ECS Fargate, Lambda). |
+| Custom images or agents that require root access and kernel tweaks. | You want a fully managed database, analytics, or event-driven service instead of self-managing software on EC2. |
+| Lift-and-shift migrations where apps expect persistent hosts. | The workload is bursty, stateless, and better served by AWS App Runner/EKS with autoscaling pods. |
+
 ## Launch & manage EC2 instances (flow)
 
 ```mermaid
@@ -21,6 +29,35 @@ flowchart TD
   I --> J[Right-size / Auto Scale / Stop or Terminate]
 ```
 
+## Architecture Variants
+
+### Web tier with Auto Scaling + ALB
+
+```mermaid
+flowchart LR
+  Users((Users)) --> ALB[Application Load Balancer]
+  ALB --> ASG[Auto Scaling Group]
+  ASG -->|Launch Template| EC2[(EC2 Instances)]
+  EC2 --> DB[(RDS/Aurora)]
+  subgraph Observability
+    CW[CloudWatch Metrics]
+    Logs[CloudWatch Logs]
+  end
+  EC2 --> Logs
+  EC2 --> CW
+```
+
+### Batch/Compute farm with Spot Fleets
+
+```mermaid
+flowchart TD
+  Job[EventBridge schedule or queue] --> Fleet[EC2 Fleet / Spot Fleet]
+  Fleet --> Spot[(Spot Instances)]
+  Spot --> Workload[Container/Script]
+  Workload --> S3[(S3 Output Bucket)]
+  Spot --> SM[Systems Manager Automation for lifecycle]
+```
+
 ## Best Practices
 
 - **Standardize how you launch instances** using Launch Templates or IaC instead of ad‑hoc console clicks; this ensures consistent AMIs, Security Groups, IAM Roles, and tags.
@@ -29,6 +66,24 @@ flowchart TD
 - **Separate OS and data** into different volumes, enable EBS encryption, and use snapshots or AWS Backup for regular, automated backups.
 - Turn on **monitoring and logging from day one** (detailed monitoring, CloudWatch Logs) and set basic alarms for CPU, status checks, disk, and network.
 - Manage lifecycle: stop or terminate unused instances, and ensure every instance has **meaningful tags** (Environment, Owner, Project, CostCenter).
+
+## Operations & Cost Lens
+
+| Operations Focus | Why it matters | Cost Lens | Optimization idea |
+| --- | --- | --- | --- |
+| Patch management & AMI hygiene | Golden AMIs + SSM Patch Manager reduce drift and downtime. | Pricing model choice | Mix Savings Plans/Reserved Instances for steady workloads; keep dev/test on On-Demand or Spot. |
+| Monitoring & remediation | CloudWatch + EventBridge or Incident Manager detect/auto-remediate failures. | Storage lifecycle | Use gp3/EBS Snapshots Archive and delete unattached volumes or idle Elastic IPs. |
+| Access control & secrets | Use IAM Roles, Parameter Store, Secrets Manager instead of local files. | Instance right-sizing | Review Cost Explorer / Compute Optimizer monthly to downsize or switch families. |
+
+## Hands-on Hook
+
+- Ready to practice? Jump to the [Auto Scaling EC2 with ALB lab](../../../05-labs/ec2-lab.md) for a guided walkthrough using Launch Templates, Target Groups, and CloudWatch alarms.
+
+## Certification Focus
+
+- **CLF-C02 Domain 2 – Security & Compliance**: Spot insecure defaults like wide-open Security Groups or hard-coded keys.
+- **SAA-C03 Domain 2 & 3 – Design Resilient and High-Performing Architectures**: Map Auto Scaling + ALB patterns and storage decisions to scenario-based questions.
+- **DVA-C02 Domain 1 – Deployment**: Know when to use EC2 vs. managed compute options in application stacks.
 
 ## Exam Notes
 

--- a/docs/en/05-labs/ec2-lab.md
+++ b/docs/en/05-labs/ec2-lab.md
@@ -1,3 +1,115 @@
 # Lab: Auto Scaling EC2 with ALB
 
-> Draft lab instructions.
+> Build a production-style web tier that scales horizontally, reports health to an Application Load Balancer, and cleans itself up when idle.
+
+## Lab Metadata
+
+| Level | Role Fit | AWS Services | Estimated Time | Cost Warning |
+| --- | --- | --- | --- | --- |
+| Intermediate | Solutions Architect, Infra/DevOps Engineer | VPC, EC2, Launch Templates, Auto Scaling, ALB, CloudWatch | 60–90 minutes | <$1 when using t3.micro and deleting resources immediately. |
+
+## Prerequisites
+
+- AWS account with permissions for VPC, IAM roles/instance profiles, ALB, Auto Scaling, CloudWatch.
+- Default VPC disabled? create a dedicated VPC with two public subnets in different AZs.
+- SSH key pair (PEM or PPK) available locally, or use EC2 Instance Connect / Systems Manager Session Manager.
+- Sample web content stored in S3 or simple `user_data` script ready.
+
+## Architecture Overview
+
+```mermaid
+flowchart LR
+  Users((Users)) --> ALB[Application Load Balancer]
+  ALB --> TG[Target Group]
+  TG --> ASG[Auto Scaling Group]
+  ASG -->|Launch Template| EC2[(EC2 Instances)]
+  EC2 --> CW[CloudWatch Metrics]
+  CW --> Alarm[Scaling Alarms]
+```
+
+## Plan
+
+1. Prepare networking + IAM role so instances can fetch updates/logs.
+2. Create a Launch Template with user data that installs a lightweight web app.
+3. Configure an ALB + Target Group with health checks on HTTP 80.
+4. Create an Auto Scaling Group tied to two subnets and scaling policies.
+5. Validate, observe scaling, then tear down every artifact.
+
+## Build
+
+### Step 1 – Network & IAM
+
+1. Create (or reuse) a VPC with two public subnets; ensure route tables point to an Internet Gateway.
+2. Define a Security Group allowing HTTP (80) from the world and SSH (22) from your IP.
+3. Create an IAM role with the `AmazonSSMManagedInstanceCore` policy so the instance can use Session Manager.
+
+### Step 2 – Launch Template
+
+1. Open **EC2 → Launch Templates → Create template**.
+2. Choose Amazon Linux 2023, `t3.micro`, attach the IAM role, and select the Security Group.
+3. Paste user data similar to:
+
+```bash
+#!/bin/bash
+dnf update -y
+dnf install -y httpd
+echo "<h1>EC2 Auto Scaling Lab</h1>" > /var/www/html/index.html
+systemctl enable --now httpd
+```
+
+4. Save template version 1.
+
+### Step 3 – Target Group & ALB
+
+1. **EC2 → Target Groups → Create target group** of type `Instances`, port 80, health check path `/`.
+2. **EC2 → Load Balancers → Create** Application Load Balancer with two public subnets, listener HTTP 80 forwarding to the new Target Group.
+
+### Step 4 – Auto Scaling Group
+
+1. **Auto Scaling Groups → Create** and select the Launch Template.
+2. Choose both subnets, attach the Target Group, desired capacity `2`, min `2`, max `4`.
+3. Add scaling policy: scale out at `CPU >= 60%` for 5 minutes, scale in at `CPU <= 20%` for 10 minutes.
+
+## Verify
+
+1. Wait for instances to show `InService` in the Target Group.
+2. Hit the ALB DNS name; you should see the lab HTML page.
+3. Generate load (e.g., `ab`/`hey` tool) to push CPU >60% and confirm a third/fourth instance launches.
+4. Stop the load and ensure the ASG scales back to two instances after cooldown.
+
+## Optimize
+
+- Enable access logs on the ALB to S3 for audit trails.
+- Add an HTTPS listener with ACM-managed certificate for production parity.
+- Replace user data with a code pipeline or image pipeline for reproducible deployments.
+- Add an Amazon CloudWatch dashboard to visualize request count, latency, and instance metrics in one place.
+
+## Tear Down
+
+1. Delete the Auto Scaling Group (which also terminates instances).
+2. Delete the Launch Template if it was created only for this lab.
+3. Delete the ALB and Target Group.
+4. Remove Security Groups, IAM roles, and key pairs if they were lab-specific.
+5. Delete the VPC/subnets/Internet Gateway if no longer needed.
+
+## Validation & Troubleshooting
+
+### Expected Results
+
+- ALB health checks stay `healthy` after launch.
+- Scaling policies add/remove instances according to the CPU alarms.
+- Cost Explorer (next day) shows only pennies of EC2/ALB usage.
+
+### Common Issues
+
+| Symptom | Likely root cause | Fix |
+| --- | --- | --- |
+| Target Group shows `unhealthy`. | Security Group missing port 80 or user data failed to start Apache. | Open port 80 inbound and review `/var/log/cloud-init-output.log`. |
+| ASG cannot launch instances. | Subnet not associated with Internet Gateway or no public IP assigned. | Enable Auto-assign public IP or add NAT + private subnets. |
+| Scaling policies never trigger. | CloudWatch alarm not bound to ASG or metric set to `Average` across entire group. | Attach alarm to policy and verify `per-instance` metrics exist. |
+
+## Reflection & Exam Mapping
+
+- Map the lab to **SAA-C03 Domain 2 (Design Resilient Architectures)** by explaining how ALB + ASG remove single points of failure.
+- Translate observations into **CLF-C02 Domain 2** style questions: Which option protects credentials? Why prefer IAM roles over static keys?
+- Capture notes on cost levers (instance types, scaling limits) to answer **SOA-C02** operational efficiency questions.

--- a/docs/vi/03-services/compute/ec2/basics.md
+++ b/docs/vi/03-services/compute/ec2/basics.md
@@ -7,6 +7,14 @@
 - Sau khi khởi chạy, bạn **kết nối** qua SSH (Linux) hoặc RDP (Windows), cấu hình ứng dụng, gắn thêm EBS volumes, và giám sát bằng CloudWatch.
 - Việc **right‑size, gắn IAM role thay vì access key, giới hạn Security Groups và bật monitoring** là nền tảng cho vận hành EC2 an toàn, hiệu quả và tối ưu chi phí.
 
+## Tổng quan sử dụng
+
+| Khi nào nên chọn EC2 | Khi nào nên cân nhắc dịch vụ khác |
+| --- | --- |
+| Cần toàn quyền kiểm soát OS, network, placement group, license đặc thù. | Chỉ cần runtime container/serverless được quản lý (ECS Fargate, Lambda). |
+| Ứng dụng yêu cầu custom agents, kernel tuning, hoặc root access toàn phần. | Muốn dịch vụ managed cho database, analytics, event – không phải tự cài trên EC2. |
+| Các workload lift-and-shift hoặc hệ thống legacy kỳ vọng máy chủ cố định. | Khối lượng công việc stateless, bùng nổ nên phù hợp App Runner hoặc EKS autoscaling. |
+
 ## Sơ đồ quy trình khởi chạy & quản lý EC2
 
 ```mermaid
@@ -22,6 +30,35 @@ flowchart TD
   I --> J[Right-size / Auto Scaling / Stop/Terminate]
 ```
 
+## Các biến thể kiến trúc
+
+### Lớp web với Auto Scaling + ALB
+
+```mermaid
+flowchart LR
+  Users((Users)) --> ALB[Application Load Balancer]
+  ALB --> ASG[Auto Scaling Group]
+  ASG -->|Launch Template| EC2[(EC2 Instances)]
+  EC2 --> DB[(RDS/Aurora)]
+  subgraph Observability
+    CW[CloudWatch Metrics]
+    Logs[CloudWatch Logs]
+  end
+  EC2 --> Logs
+  EC2 --> CW
+```
+
+### Batch/Compute farm với Spot Fleet
+
+```mermaid
+flowchart TD
+  Job[Lịch EventBridge hoặc hàng đợi] --> Fleet[EC2 Fleet / Spot Fleet]
+  Fleet --> Spot[(Spot Instances)]
+  Spot --> Workload[Container/Script]
+  Workload --> S3[(S3 Output Bucket)]
+  Spot --> SM[Systems Manager Automation lifecycle]
+```
+
 ## Best Practices
 
 - **Chuẩn hóa quy trình khởi chạy**: dùng Launch Template hoặc IaC (CloudFormation/Terraform) thay vì click tay để đảm bảo cấu hình nhất quán.
@@ -30,6 +67,24 @@ flowchart TD
 - **Tách OS và data volumes**, bật EBS encryption mặc định và dùng snapshots tự động để dễ backup/restore và migration.
 - **Áp dụng monitoring & logging ngay từ đầu**: bật detailed monitoring, gửi logs lên CloudWatch Logs, đặt alarms cho CPU, status checks, disk, network.
 - **Thực hành quản lý vòng đời**: dừng instances không dùng, terminate hẳn môi trường test/lab khi xong, và gắn tags (Environment/Owner/Project) để tracking chi phí.
+
+## Lăng kính vận hành & chi phí
+
+| Trọng tâm vận hành | Lý do quan trọng | Trọng tâm chi phí | Ý tưởng tối ưu |
+| --- | --- | --- | --- |
+| Quản lý bản vá & vòng đời AMI | Golden AMI + SSM Patch Manager giảm drift và downtime. | Mô hình giá | Kết hợp Savings Plans/Reserved Instances cho workload ổn định; dev/test dùng On-Demand hoặc Spot. |
+| Giám sát & phản ứng | CloudWatch + EventBridge/Incident Manager giúp phát hiện và tự động khắc phục sự cố. | Vòng đời storage | Dùng gp3, EBS Snapshots Archive, xóa volume rời rạc hoặc Elastic IP không dùng. |
+| Kiểm soát truy cập & secrets | Áp dụng IAM Role, Parameter Store, Secrets Manager thay vì lưu file cục bộ. | Right-sizing instance | Dùng Cost Explorer/Compute Optimizer hàng tháng để hạ cấu hình hoặc đổi dòng máy. |
+
+## Hands-on Hook
+
+- Thực hành ngay với [lab Auto Scaling EC2 + ALB](../../../05-labs/ec2-lab.md) để đi qua Launch Template, Target Group và cảnh báo CloudWatch.
+
+## Trọng tâm chứng chỉ
+
+- **CLF-C02 Domain 2 – Security & Compliance**: Nhận diện lỗi thiết lập như Security Group mở rộng hoặc hard-code key.
+- **SAA-C03 Domain 2 & 3 – Thiết kế kiến trúc resilient & hiệu năng cao**: Hiểu cách kết hợp Auto Scaling + ALB, lựa chọn storage theo scenario.
+- **DVA-C02 Domain 1 – Deployment**: Biết khi nào dùng EC2 so với dịch vụ compute managed trong stack ứng dụng.
 
 ## Exam Notes
 

--- a/docs/vi/05-labs/ec2-lab.md
+++ b/docs/vi/05-labs/ec2-lab.md
@@ -1,3 +1,115 @@
-# Lab: EC2 + Auto Scaling
+# Lab: EC2 + Auto Scaling + ALB
 
-> Hướng dẫn từng bước.
+> Dựng nhanh lớp web có khả năng mở rộng ngang với Auto Scaling Group, kiểm tra sức khỏe qua Application Load Balancer và tự dọn sau khi hoàn tất.
+
+## Thông tin lab
+
+| Level | Đối tượng phù hợp | Dịch vụ AWS | Thời lượng ước tính | Cảnh báo chi phí |
+| --- | --- | --- | --- | --- |
+| Intermediate | Solutions Architect, Infra/DevOps Engineer | VPC, EC2, Launch Template, Auto Scaling, ALB, CloudWatch | 60–90 phút | <1 USD khi dùng t3.micro và xóa tài nguyên ngay. |
+
+## Điều kiện tiên quyết
+
+- Tài khoản AWS có quyền tạo VPC, IAM role/instance profile, ALB, Auto Scaling, CloudWatch.
+- Nếu đã xóa Default VPC, hãy tạo VPC riêng với hai public subnet ở hai AZ khác nhau.
+- Có sẵn SSH key pair hoặc dùng EC2 Instance Connect / Systems Manager Session Manager.
+- Chuẩn bị nội dung web mẫu (S3 object) hoặc script `user_data` cài Apache.
+
+## Kiến trúc mục tiêu
+
+```mermaid
+flowchart LR
+  Users((Users)) --> ALB[Application Load Balancer]
+  ALB --> TG[Target Group]
+  TG --> ASG[Auto Scaling Group]
+  ASG -->|Launch Template| EC2[(EC2 Instances)]
+  EC2 --> CW[CloudWatch Metrics]
+  CW --> Alarm[Scaling Alarms]
+```
+
+## Plan
+
+1. Chuẩn bị network + IAM role để instances tải patch/log.
+2. Tạo Launch Template với user data dựng web server nhẹ.
+3. Cấu hình ALB + Target Group với health check HTTP 80.
+4. Tạo Auto Scaling Group gắn hai subnet và policy scale.
+5. Kiểm tra, tạo tải giả lập rồi dọn sạch mọi tài nguyên.
+
+## Build
+
+### Bước 1 – Network & IAM
+
+1. Tạo (hoặc tái sử dụng) VPC có hai public subnet; route table phải trỏ tới Internet Gateway.
+2. Security Group: mở HTTP (80) cho mọi nguồn, SSH (22) chỉ cho IP của bạn.
+3. Tạo IAM role với policy `AmazonSSMManagedInstanceCore` để dùng Session Manager.
+
+### Bước 2 – Launch Template
+
+1. Vào **EC2 → Launch Templates → Create template**.
+2. Chọn Amazon Linux 2023, `t3.micro`, gắn IAM role và Security Group vừa tạo.
+3. Thêm user data:
+
+```bash
+#!/bin/bash
+dnf update -y
+dnf install -y httpd
+echo "<h1>EC2 Auto Scaling Lab</h1>" > /var/www/html/index.html
+systemctl enable --now httpd
+```
+
+4. Lưu template version 1.
+
+### Bước 3 – Target Group & ALB
+
+1. **EC2 → Target Groups → Create** loại `Instances`, port 80, health check path `/`.
+2. **EC2 → Load Balancers → Create** Application Load Balancer, chọn hai public subnet, listener HTTP 80 forward tới Target Group.
+
+### Bước 4 – Auto Scaling Group
+
+1. **Auto Scaling Groups → Create** rồi chọn Launch Template.
+2. Chọn hai subnet, gắn Target Group, Desired=2, Min=2, Max=4.
+3. Tạo scaling policy: scale-out khi `CPU >= 60%` 5 phút, scale-in khi `CPU <= 20%` 10 phút.
+
+## Verify
+
+1. Chờ Target Group báo `healthy`.
+2. Gõ DNS ALB, trang HTML lab phải hiển thị.
+3. Dùng công cụ như `ab`/`hey` tạo tải để CPU >60% và quan sát instance thứ 3/4 được tạo.
+4. Dừng tải và xác nhận ASG giảm về hai instance sau cooldown.
+
+## Optimize
+
+- Bật ALB access log lên S3 để audit.
+- Thêm listener HTTPS + chứng chỉ ACM cho môi trường gần production.
+- Thay user data bằng pipeline (CodeDeploy/EC2 Image Builder) để tái lập dễ dàng.
+- Tạo dashboard CloudWatch để gom RequestCount, Latency, CPU, HealthyHostCount.
+
+## Tear Down
+
+1. Xóa Auto Scaling Group (đồng thời terminate instances).
+2. Xóa Launch Template nếu chỉ phục vụ lab.
+3. Xóa ALB và Target Group.
+4. Gỡ Security Group, IAM role, key pair nếu chỉ dùng cho lab.
+5. Xóa VPC/subnet/Internet Gateway nếu không còn nhu cầu.
+
+## Validation & Troubleshooting
+
+### Kết quả mong đợi
+
+- ALB health check ở trạng thái `healthy` ổn định.
+- Scaling policy kích hoạt khi CPU vượt ngưỡng và giảm khi tải hạ.
+- Báo cáo chi phí hôm sau chỉ ghi nhận vài cent cho EC2/ALB.
+
+### Lỗi thường gặp
+
+| Triệu chứng | Nguyên nhân khả dĩ | Cách khắc phục |
+| --- | --- | --- |
+| Target Group `unhealthy`. | SG chưa mở port 80 hoặc user data không khởi động Apache. | Mở port 80 inbound, kiểm tra `/var/log/cloud-init-output.log`. |
+| ASG không tạo được instance. | Subnet không ra Internet hoặc instance không có public IP. | Bật auto-assign public IP hoặc thêm NAT cho private subnet. |
+| Không thấy scaling. | CloudWatch alarm không gắn với ASG hoặc metric đặt `Average` toàn nhóm. | Liên kết alarm đúng policy và kiểm tra metric per-instance. |
+
+## Reflection & Exam Mapping
+
+- Liên hệ **SAA-C03 Domain 2**: giải thích vì sao ALB + ASG loại bỏ single point of failure.
+- Biến trải nghiệm thành câu hỏi kiểu **CLF-C02 Domain 2**: bảo vệ credential bằng IAM Role, Security Group hẹp.
+- Ghi chú đòn bẩy chi phí (loại instance, giới hạn scaling) để trả lời câu hỏi tối ưu vận hành trong **SOA-C02**.


### PR DESCRIPTION
## Summary
- add a "service at a glance" decision table, architecture variants, and operations & certification focus areas to the EC2 basics article in both English and Vietnamese
- create a structured Auto Scaling EC2 lab guide in English and Vietnamese with metadata, step-by-step instructions, troubleshooting, and reflection prompts

## Testing
- not run (documentation changes only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6916eef4f218832a945f4d8c9257970b)